### PR TITLE
Use EXO_DB_HOST variable instead of hardcoding 'mysql' in the jdbc url

### DIFF
--- a/setenv-docker-customize.sh
+++ b/setenv-docker-customize.sh
@@ -59,8 +59,8 @@ else
       ;;
     mysql)
       cat /opt/exo/conf/server-mysql.xml > /opt/exo/conf/server.xml
-      replace_in_file /opt/exo/conf/server.xml "jdbc:mysql://localhost:3306/plf" "jdbc:mysql://mysql:${EXO_DB_PORT}/${EXO_DB_NAME}"
-      # sed -i 's,jdbc:mysql://localhost:3306/plf,jdbc:mysql://mysql:'${EXO_DB_PORT}'/'${EXO_DB_NAME}',g' /opt/exo/conf/server.xml
+      replace_in_file /opt/exo/conf/server.xml "jdbc:mysql://localhost:3306/plf" "jdbc:mysql://${EXO_DB_HOST}:${EXO_DB_PORT}/${EXO_DB_NAME}"
+      # sed -i 's,jdbc:mysql://localhost:3306/plf,jdbc:mysql://'${EXO_DB_HOST}':'${EXO_DB_PORT}'/'${EXO_DB_NAME}',g' /opt/exo/conf/server.xml
       replace_in_file /opt/exo/conf/server.xml 'username="plf" password="plf"' 'username="'${EXO_DB_USER}'" password="'${EXO_DB_PASSWORD}'"'
       # sed -i 's,username="plf" password="plf",username="'${EXO_DB_USER}'" password="'${EXO_DB_PASSWORD}'",g' /opt/exo/conf/server.xml
       ;;


### PR DESCRIPTION
This is currently not possible to use the exo-community docker image with mysql, it throws the following error :

Caused by: com.mysql.jdbc.exceptions.jdbc4.CommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_92]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_92]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_92]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_92]
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:404) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	at com.mysql.jdbc.SQLError.createCommunicationsException(SQLError.java:988) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	at com.mysql.jdbc.MysqlIO.<init>(MysqlIO.java:341) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	at com.mysql.jdbc.ConnectionImpl.coreConnect(ConnectionImpl.java:2251) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	at com.mysql.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:2104) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	... 36 common frames omitted
Caused by: java.net.UnknownHostException: mysql
	at java.net.InetAddress.getAllByName0(InetAddress.java:1280) ~[na:1.8.0_92]
	at java.net.InetAddress.getAllByName(InetAddress.java:1192) ~[na:1.8.0_92]
	at java.net.InetAddress.getAllByName(InetAddress.java:1126) ~[na:1.8.0_92]
	at com.mysql.jdbc.StandardSocketFactory.connect(StandardSocketFactory.java:188) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	at com.mysql.jdbc.MysqlIO.<init>(MysqlIO.java:300) ~[mysql-connector-java-5.1.39.jar:5.1.39]
	... 38 common frames omitted

This PR removes the hardcoded 'mysql' value in the jdbc url by using the variable EXO_DB_HOST instead.