### PR TITLE
Issue #5 Synchronize the platform and chat version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ LABEL   maintainer="eXo Platform <docker@exoplatform.com>"
 
 # Environment variables
 ENV EXO_VERSION 5.1.0-RC10
+ENV CHAT_VERSION 2.1.0-RC10
 
 ENV EXO_APP_DIR   /opt/exo
 ENV EXO_CONF_DIR  /etc/exo

--- a/docker-compose-chat.yml
+++ b/docker-compose-chat.yml
@@ -22,7 +22,7 @@ services:
       EXO_DB_USER: exo
       EXO_DB_PASSWORD: my-secret-pw
       EXO_MONGO_HOST: mongo
-      EXO_ADDONS_LIST: exo-chat
+      EXO_ADDONS_LIST: exo-chat:$${CHAT_VERSION}
     volumes:
       - exo_data:/srv/exo
       - exo_logs:/var/log/exo


### PR DESCRIPTION
The chat version installed using the docker-compose-chat.yml file is from the previous release and is not compatible with the current version of platform.
This patch forces to use a version specified in the Dockerfile.