### PR TITLE
Add a volume for codec folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ARG ARCHIVE_BASE_DIR=platform-community-${EXO_VERSION}
 
 ENV EXO_APP_DIR   /opt/exo
 ENV EXO_CONF_DIR  /etc/exo
+ENV EXO_CODEC_DIR /etc/exo/codec
 ENV EXO_DATA_DIR  /srv/exo
 ENV EXO_SHARED_DATA_DIR    /srv/exo/shared
 ENV EXO_LOG_DIR   /var/log/exo
@@ -78,6 +79,7 @@ RUN if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
   mv /srv/downloads/${ARCHIVE_BASE_DIR} ${EXO_APP_DIR} && \
   chown -R ${EXO_USER}:${EXO_GROUP} ${EXO_APP_DIR} && \
   ln -s ${EXO_APP_DIR}/gatein/conf /etc/exo && \
+  mkdir -p ${EXO_CODEC_DIR} && chown ${EXO_USER}:${EXO_GROUP} ${EXO_CODEC_DIR} && \
   rm -rf ${EXO_APP_DIR}/logs && ln -s ${EXO_LOG_DIR} ${EXO_APP_DIR}/logs
 
 # Install Docker customization file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - "8080:8080"
     volumes:
       - exo_data:/srv/exo
+      - exo_codec:/etc/exo/codec:rw
       - exo_logs:/var/log/exo
     depends_on:
       - mysql
@@ -67,6 +68,7 @@ services:
       - mongo_data:/data/db:rw
 volumes:
   exo_data:
+  exo_codec:
   exo_logs:
   mysql_data:
   search_data:


### PR DESCRIPTION
Before this fix, the codec folder was not saved as a volume, so the file codeckey.txt was dropped on container down When restarting, the server refused to start due to different codec key.

This commit make the codec folder as volume so that it is locally saved as data