### PR TITLE
Add multi-platform support (arm64/amd64)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Build, Sign, and Publish Docker Image
+name: Create and publish a Docker image
 
 on:
   push:
@@ -10,12 +10,16 @@ concurrency:
   group: docker-publish-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  DOCKER_IMAGE: "exoplatform/exo-community"
+  GHCR_IMAGE: "exo-docker/exo-community"
+
 jobs:
   parse-docker-build-env:
-    name: "Parse Docker Build Environment"
+    name: 'Parse Docker Build Environment'
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.detect-push-event.outputs.image_tag }}
+      buildTags: ${{ steps.detect-push-event.outputs.buildTags }}
     steps:
       - name: Extract tag from ref
         id: detect-push-event
@@ -23,29 +27,152 @@ jobs:
           if [[ "${GITHUB_REF}" =~ ^refs/tags/(.+)$ ]]; then
             TAG="${BASH_REMATCH[1]}"
             echo "Detected tag push: ${TAG}"
-            echo "image_tag=${TAG}" >> "${GITHUB_OUTPUT}"
+            echo "Building docker tag: ${TAG}"
+            echo "buildTags=${TAG}" >> "${GITHUB_OUTPUT}"
           else
             echo "Unsupported ref: ${GITHUB_REF}"
             exit 1
           fi
 
-  build-and-sign-dockerhub-image:
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    runs-on: ubuntu-latest
+  build-platforms:
+    name: "Build ${{ matrix.platform }}"
+    runs-on: ${{ matrix.runner }}
     needs: parse-docker-build-env
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
-      - name: "Build and sign Docker images"
-        uses: exo-actions/buildDockerImage-action@v1
+      - uses: exo-actions/buildDockerImage-action/build-and-push-image@v1
+        id: build
         with:
-          dockerImage: "exoplatform/exo-community"
-          dockerImageTag: ${{ needs.parse-docker-build-env.outputs.image_tag }}
-          cosignImage: true
-          attestImage: true
+          dockerImage: ${{ env.DOCKER_IMAGE }}
+          dockerImageTag: ${{ needs.parse-docker-build-env.outputs.buildTags }}
+          platforms: ${{ matrix.platform }}
+          qemu: "false"
+          annotations: |
+            org.opencontainers.image.title=eXo Platform Community
+            org.opencontainers.image.description=Docker image for eXo Platform Community Edition
+            org.opencontainers.image.vendor=eXo Platform
+            org.opencontainers.image.source=https://github.com/exo-docker/exo-community
+            org.opencontainers.image.authors=eXo Platform <docker@exoplatform.com>
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Save digest
+        run: echo "${{ steps.build.outputs.digest }}" > "/tmp/${{ matrix.arch }}.digest"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.arch }}-digest
+          path: /tmp/${{ matrix.arch }}.digest
+
+  merge-dockerhub:
+    name: "Merge multi-arch manifest (Docker Hub)"
+    runs-on: ubuntu-latest
+    needs:
+      - parse-docker-build-env
+      - build-platforms
+    permissions:
+      actions: read
+    outputs:
+      tags: ${{ steps.merge.outputs.tags }}
+      digest: ${{ steps.get-digest.outputs.digest }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: amd64-digest
+          path: /tmp/digests
+      - uses: actions/download-artifact@v8
+        with:
+          name: arm64-digest
+          path: /tmp/digests
+      - uses: exo-actions/buildDockerImage-action/merge-manifest@v1
+        id: merge
+        with:
+          dockerImage: ${{ env.DOCKER_IMAGE }}
+          dockerImageTag: ${{ needs.parse-docker-build-env.outputs.buildTags }}
+          digestsDir: /tmp/digests
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Get merged digest
+        id: get-digest
+        run: |
+          TAG=$(echo "${{ needs.parse-docker-build-env.outputs.buildTags }}" | cut -d, -f1)
+          DIGEST=$(docker buildx imagetools inspect docker.io/${{ env.DOCKER_IMAGE }}:${TAG} --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+  mirror-to-ghcr:
+    name: "Mirror to GitHub Container Registry"
+    runs-on: ubuntu-latest
+    needs:
+      - parse-docker-build-env
+      - merge-dockerhub
+    permissions:
+      packages: write
+    outputs:
+      digest: ${{ steps.mirror.outputs.digest }}
+      tagsJson: ${{ steps.mirror.outputs.tagsJson }}
+    steps:
+      - uses: exo-actions/buildDockerImage-action/mirror-image@v1
+        id: mirror
+        with:
+          sourceImage: ${{ env.DOCKER_IMAGE }}
+          sourceTag: ${{ needs.parse-docker-build-env.outputs.buildTags }}
+          targetRegistry: ghcr.io
+          targetImage: ${{ env.GHCR_IMAGE }}
+          SOURCE_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          SOURCE_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          TARGET_USERNAME: ${{ secrets.SWF_ACTOR }}
+          TARGET_PASSWORD: ${{ secrets.SWF_TOKEN }}
+
+  cosign-ghcr:
+    name: "Cosign GitHub Container Registry image"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    needs:
+      - parse-docker-build-env
+      - merge-dockerhub
+      - mirror-to-ghcr
+    steps:
+      - uses: exo-actions/buildDockerImage-action/cosign-image@v1
+        with:
+          dockerImage: ${{ env.GHCR_IMAGE }}
+          dockerImageTag: ${{ needs.mirror-to-ghcr.outputs.tagsJson }}
+          dockerImageDigest: ${{ needs.mirror-to-ghcr.outputs.digest }}
+          dockerRegistry: ghcr.io
+          DOCKER_USERNAME: ${{ secrets.SWF_ACTOR }}
+          DOCKER_PASSWORD: ${{ secrets.SWF_TOKEN }}
+          cosignImage: true
+          cosignOidcImage: true
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+  attest-ghcr:
+    name: "Attest GitHub Container Registry image"
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+      artifact-metadata: write
+    needs:
+      - parse-docker-build-env
+      - merge-dockerhub
+      - mirror-to-ghcr
+    steps:
+      - uses: exo-actions/buildDockerImage-action/attest-image@v1
+        with:
+          dockerImage: ${{ env.GHCR_IMAGE }}
+          dockerImageDigest: ${{ needs.mirror-to-ghcr.outputs.digest }}
+          dockerRegistry: ghcr.io
+          attestImage: true
+          attestImageRegistry: ghcr.io
+          DOCKER_USERNAME: ${{ secrets.SWF_ACTOR }}
+          DOCKER_PASSWORD: ${{ secrets.SWF_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,14 @@
 #           docker run -d -p 8080:8080 -v $(pwd)/setenv-customize.sh:/opt/exo/bin/setenv-customize.sh:ro exoplatform/exo-community
 
 FROM  exoplatform/jdk:openjdk-21-ubuntu-2604
-LABEL   maintainer="eXo Platform <docker@exoplatform.com>"
 
-# Install the needed packages
-RUN apt-get -qq update && \
-  apt-get -qq -y upgrade ${_APT_OPTIONS} && \
-  apt-get -qq -y install ${_APT_OPTIONS} xmlstarlet jq && \
-  echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
-  echo "ttf-mscorefonts-installer msttcorefonts/present-mscorefonts-eula note" | debconf-set-selections && \
-  apt-get -qq -y install ${_APT_OPTIONS} ttf-mscorefonts-installer && \
-  apt-get -qq -y install ${_APT_OPTIONS} libreoffice-calc libreoffice-draw libreoffice-impress libreoffice-math libreoffice-writer && \
-  apt-get -qq -y autoremove && \
-  apt-get -qq -y clean && \
-  rm -rf /var/lib/apt/lists/*
-# Check if the released binary was modified and make the build fail if it is the case
-RUN wget -nv -q -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_amd64 && \
-  echo "35d8b1123849350daa5ff11dd23c81b8 /usr/bin/yq" | md5sum -c - \
-  || { \
-  echo "ERROR: the [/usr/bin/yq] binary downloaded from a github release was modified while is should not !!"; \
-  return 1; \
-  } && chmod a+x /usr/bin/yq
+LABEL org.opencontainers.image.authors="eXo Platform <docker@exoplatform.com>" \
+      org.opencontainers.image.title="eXo Platform Community" \
+      org.opencontainers.image.description="Docker image for eXo Platform Community Edition" \
+      org.opencontainers.image.vendor="eXo Platform" \
+      org.opencontainers.image.source="https://github.com/exo-docker/exo-community"
+
+ARG YQ_VERSION=v4.53.4
 
 # Build Arguments and environment variables
 ARG EXO_VERSION=7.1.0
@@ -43,30 +31,74 @@ ARG DOWNLOAD_USER
 # Default base directory on the plf archive
 ARG ARCHIVE_BASE_DIR=platform-community-${EXO_VERSION}
 
-ENV EXO_APP_DIR=/opt/exo
-ENV EXO_CONF_DIR=/etc/exo
-ENV EXO_CODEC_DIR=/etc/exo/codec
-ENV EXO_DATA_DIR=/srv/exo
-ENV EXO_SHARED_DATA_DIR=/srv/exo/shared
-ENV EXO_LOG_DIR=/var/log/exo
-ENV EXO_TMP_DIR=/tmp/exo-tmp
-
-ENV EXO_USER=exo
-ENV EXO_GROUP=${EXO_USER}
-
+ENV EXO_APP_DIR=/opt/exo \
+    EXO_CONF_DIR=/etc/exo \
+    EXO_CODEC_DIR=/etc/exo/codec \
+    EXO_DATA_DIR=/srv/exo \
+    EXO_SHARED_DATA_DIR=/srv/exo/shared \
+    EXO_LOG_DIR=/var/log/exo \
+    EXO_TMP_DIR=/tmp/exo-tmp \
+    EXO_USER=exo \
+    EXO_GROUP=exo \
+    DEBIAN_FRONTEND=noninteractive
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-# giving all rights to eXo user
-RUN useradd --create-home -u 999 --user-group --shell /bin/bash ${EXO_USER}
+RUN useradd --create-home -u 999 --user-group --shell /bin/bash --no-log-init ${EXO_USER}
+
+# Install the needed packages
+RUN apt-get -qq update && \
+  apt-get -qq -y upgrade ${_APT_OPTIONS} && \
+  apt-get -qq -y install --no-install-recommends ${_APT_OPTIONS} debconf-utils && \
+  echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
+  echo "ttf-mscorefonts-installer msttcorefonts/present-mscorefonts-eula note" | debconf-set-selections && \
+  apt-get -qq -y install ${_APT_OPTIONS} \
+    xmlstarlet \
+    jq \
+    curl \
+    unzip \
+    ca-certificates \
+    fontconfig \
+    ttf-mscorefonts-installer \
+    libreoffice-calc \
+    libreoffice-draw \
+    libreoffice-impress \
+    libreoffice-math \
+    libreoffice-writer && \
+  apt-get -qq -y autoremove && \
+  apt-get -qq -y clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Download yq with architecture detection and checksum verification
+RUN YQ_ARCH=$(dpkg --print-architecture) && \
+    if [ "$YQ_ARCH" = "amd64" ]; then \
+        YQ_SHA256="f67d8a6a2dc2308c961f83d5ba8707fd4c7c44ad77902fef87eb3a4646cdfa2a"; \
+    elif [ "$YQ_ARCH" = "arm64" ]; then \
+        YQ_SHA256="8c3cf4cff01536588947b6e0ba1544768039e34054cd9ca8a9e4c5706dfb8631"; \
+    else \
+        echo "Unsupported architecture: $YQ_ARCH"; exit 1; \
+    fi && \
+    curl -fsSL -o /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}" && \
+    echo "${YQ_SHA256} /usr/bin/yq" | sha256sum -c - \
+    || { \
+    echo "ERROR: the [/usr/bin/yq] binary downloaded from a github release was modified while it should not !!"; \
+    exit 1; \
+    } && \
+    chmod a+x /usr/bin/yq
+
+# Drop pebble as we use tini
+RUN rm -f /usr/bin/pebble \
+    && rm -rf /var/lib/pebble \
+    && rm -rf /etc/pebble
 
 # Create needed directories
-RUN mkdir -p ${EXO_DATA_DIR}   && chown ${EXO_USER}:${EXO_GROUP} ${EXO_DATA_DIR} \
-    && mkdir -p ${EXO_SHARED_DATA_DIR}  && chown ${EXO_USER}:${EXO_GROUP} ${EXO_SHARED_DATA_DIR}  \
-    && mkdir -p ${EXO_TMP_DIR} && chown ${EXO_USER}:${EXO_GROUP} ${EXO_TMP_DIR} \
-    && mkdir -p ${EXO_LOG_DIR} && chown ${EXO_USER}:${EXO_GROUP} ${EXO_LOG_DIR}
+RUN mkdir -p ${EXO_DATA_DIR}          && chown ${EXO_USER}:${EXO_GROUP} ${EXO_DATA_DIR} \
+    && mkdir -p ${EXO_SHARED_DATA_DIR} && chown ${EXO_USER}:${EXO_GROUP} ${EXO_SHARED_DATA_DIR} \
+    && mkdir -p ${EXO_TMP_DIR}        && chown ${EXO_USER}:${EXO_GROUP} ${EXO_TMP_DIR} \
+    && mkdir -p ${EXO_LOG_DIR}        && chown ${EXO_USER}:${EXO_GROUP} ${EXO_LOG_DIR}
 
 # Install eXo Platform
-RUN if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
+RUN set -e; \
+  if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
   if [ ! -n "${DOWNLOAD_URL}" ]; then \
   echo "Building an image with eXo Platform version : ${EXO_VERSION}"; \
   EXO_VERSION_SHORT=$(echo ${EXO_VERSION} | awk -F "\." '{ print $1"."$2}'); \
@@ -82,9 +114,8 @@ RUN if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
   rm -rf ${EXO_APP_DIR}/logs && ln -s ${EXO_LOG_DIR} ${EXO_APP_DIR}/logs
 
 # Install Docker customization file
-ADD scripts/setenv-docker-customize.sh ${EXO_APP_DIR}/bin/setenv-docker-customize.sh
+COPY --chown=${EXO_USER}:${EXO_GROUP} scripts/setenv-docker-customize.sh ${EXO_APP_DIR}/bin/setenv-docker-customize.sh
 RUN chmod 755 ${EXO_APP_DIR}/bin/setenv-docker-customize.sh && \
-  chown ${EXO_USER}:${EXO_GROUP} ${EXO_APP_DIR}/bin/setenv-docker-customize.sh && \
   sed -i '/# Load custom settings/i \
   \# Load custom settings for docker environment\n\
   [ -r "$CATALINA_BASE/bin/setenv-docker-customize.sh" ] \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The eXo Platform Community edition Docker image support `HSQLDB` (for testing) a
 | exoplatform/exo-community:4.2     | 7   | 4.2 Community edition |
 | exoplatform/exo-community:4.1     | 7   | 4.1 Community edition |
 
+> **Multi-Architecture Support**: Starting from version `7.3.0`, eXo Platform Community Docker images are built for both `linux/amd64` and `linux/arm64` architectures. This allows running eXo Platform Community on Apple Silicon (M1/M2/M3), AWS Graviton, and other ARM64-based systems. Previous versions are amd64 only.
+
 The image is compatible with the following databases system :  `MySQL` (default) / `HSQLDB` / `PostgreSQL`
 
 - [Quick start](#quick-start)

--- a/scripts/setenv-docker-customize.sh
+++ b/scripts/setenv-docker-customize.sh
@@ -312,9 +312,9 @@ else
     i=0
     while [ $i -ge 0 ]; do
       # Declare component
-      type=$(yq read /etc/exo/host.yml components[$i].type)
+      type=$(yq -r .components[$i].type /etc/exo/host.yml)
       if [ "${type}" != "null" ]; then
-        className=$(yq read /etc/exo/host.yml components[$i].className)
+        className=$(yq -r .components[$i].className /etc/exo/host.yml)
         echo "Declare ${type} ${className}"
         xmlstarlet ed -L -s "/Server/Service/Engine/Host" -t elem -n "${type}TMP" -v "" \
             -i "//${type}TMP" -t attr -n "className" -v "${className}" \
@@ -326,9 +326,9 @@ else
         # Add component attributes
         j=0
         while [ $j -ge 0 ]; do
-          attributeName=$(yq read /etc/exo/host.yml components[$i].attributes[$j].name)
+          attributeName=$(yq -r .components[$i].attributes[$j].name /etc/exo/host.yml)
           if [ "${attributeName}" != "null" ]; then
-            attributeValue=$(yq read /etc/exo/host.yml components[$i].attributes[$j].value | tr -d "'")
+            attributeValue=$(yq -r .components[$i].attributes[$j].value /etc/exo/host.yml | tr -d "'")
             xmlstarlet ed -L -i "//${type}TMP" -t attr -n "${attributeName}" -v "${attributeValue}" \
                 /opt/exo/conf/server.xml || {
               echo "ERROR during xmlstarlet processing (adding ${className} / ${attributeName})"


### PR DESCRIPTION
Switch the publish workflow to a native multi-arch matrix build (linux/amd64 on ubuntu-latest, linux/arm64 on ubuntu-24.04-arm) with manifest merge, GHCR mirroring (ghcr.io/exo-docker/exo-community) and cosign/attest, restoring GHCR publishing that was dropped after 7.0.

Align the Dockerfile: add OCI labels, replace the amd64-only yq v1.15.0 (md5) download with yq v4 architecture detection and per-arch SHA256 verification, drop pebble, use DEBIAN_FRONTEND, --no-log-init, COPY --chown and set -e. Preserve the LibreOffice and ttf-mscorefonts install.

Migrate scripts/setenv-docker-customize.sh yq calls from v1/v2 to v4 syntax.

Document arm64 support in README from version 7.3.0.